### PR TITLE
refactor: replace builtin prototype method with Object.prototype equi…

### DIFF
--- a/src/experts/thread.js
+++ b/src/experts/thread.js
@@ -29,7 +29,7 @@ class Thread {
 
   get hasAssistantMetadata() {
     return (
-      this.metadata.hasOwnProperty("assistant") &&
+      Object.prototype.hasOwnProperty.call(this.metadata, 'assistant') &&
       this.metadata.assistant.length > 0
     );
   }


### PR DESCRIPTION
It is preferable to call certain `Object.prototype` methods through `Object` on object instances instead of using the builtins directly.